### PR TITLE
Add JS equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,22 @@ Simple binary to allow for experiments. Just pipe a command doc over stdin into 
 Find the command syntax here: https://docs.mongodb.com/manual/reference/command/
 
 ### Setup & Usage
+
+#### Rust
+
 - Have a Rust toolchain.
 - `cargo build` to build the binary.
 - `docker-compose up -d` for the test MongoDB.
 - `./target/debug/mongo-commands <your-json-cmd-string>` to invoke the binary with an arg.
 - OR: `cat your.json | ./target/debug/mongo-commands` to invoke the binary with stdin.
 
+#### JS
+
+- Have Node.js installed
+- `npm install`
+- `node src/main.js <your-json-cmd-string>` to invoke the binary with an arg.
+- OR: `cat your.json | node src/main.js` to invoke the binary with stdin.
+
 ### Examples
+
 Take a look at the examples folder. Just use it like: `cat ./examples/insert.json | ./target/debug/mongo-commands`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,133 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/node": {
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
+      "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA=="
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bson": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.3.tgz",
+      "integrity": "sha512-qVX7LX79Mtj7B3NPLzCfBiCP6RAsjiV8N63DjlaVVpZW+PFoDTxQ4SeDbSpcqgE6mXksM5CAwZnXxxxn/XwC0g==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+    },
+    "get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA=="
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "mongodb": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.3.tgz",
+      "integrity": "sha512-lHvTqODBiSpuqjpCj48DOyYWS6Iq6ElJNUiH9HWdQtONyOfjgsKzJULipWduMGsSzaNO4nFi/kmlMFCLvjox/Q==",
+      "requires": {
+        "bson": "^4.5.2",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.0.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+      "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^9.1.0"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-url": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+      "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+      "requires": {
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mongo-raw-cmd-experiments",
+  "version": "1.0.0",
+  "description": "Simple binary to allow for experiments. Just pipe a command doc over stdin into the binary or write it as first argument. Find the command syntax here: https://docs.mongodb.com/manual/reference/command/",
+  "main": "index.js",
+  "type": "module",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dpetrick/mongo-raw-cmd-experiments.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dpetrick/mongo-raw-cmd-experiments/issues"
+  },
+  "homepage": "https://github.com/dpetrick/mongo-raw-cmd-experiments#readme",
+  "dependencies": {
+    "get-stdin": "9.0.0",
+    "mongodb": "4.1.3"
+  },
+  "devDependencies": {
+    "ts-node": "10.3.0",
+    "typescript": "4.4.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,29 +1,8 @@
 {
-  "name": "mongo-raw-cmd-experiments",
-  "version": "1.0.0",
-  "description": "Simple binary to allow for experiments. Just pipe a command doc over stdin into the binary or write it as first argument. Find the command syntax here: https://docs.mongodb.com/manual/reference/command/",
-  "main": "index.js",
+  "private": true,
   "type": "module",
-  "directories": {
-    "example": "examples"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dpetrick/mongo-raw-cmd-experiments.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/dpetrick/mongo-raw-cmd-experiments/issues"
-  },
-  "homepage": "https://github.com/dpetrick/mongo-raw-cmd-experiments#readme",
   "dependencies": {
     "get-stdin": "9.0.0",
     "mongodb": "4.1.3"
-  },
-  "devDependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
     "get-stdin": "9.0.0",
     "mongodb": "4.1.3"
   },
-  "devDependencies": {
-    "ts-node": "10.3.0",
-    "typescript": "4.4.4"
-  }
+  "devDependencies": {}
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,38 @@
+import { MongoClient } from "mongodb"
+import getStdin from "get-stdin"
+
+const url =
+  "mongodb://prisma:prisma@127.0.0.1:27017/testdb?authSource=admin&retryWrites=true"
+
+const client = new MongoClient(url, {
+  useUnifiedTopology: true,
+  useNewUrlParser: true,
+})
+async function main() {
+  // Connect using MongoClient
+  const doc = JSON.parse(process.argv[2] || (await getStdin()))
+
+  // Connect to the MongoDB client
+  await client.connect()
+
+  // Select the db, when blank, it uses the connection string URL
+  const db = client.db()
+
+  // This is where the MongoDB JS driver seems slightly higher-level
+  if ("find" in doc) {
+    const collection = db.collection(doc["find"])
+    const result = await collection.find(doc["filter"]).toArray()
+    console.log(result)
+    return
+  }
+  if ("insert" in doc) {
+    const collection = db.collection(doc["insert"])
+    const result = await collection.insertMany(doc["documents"])
+    console.log(result)
+    return
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => client.close())


### PR DESCRIPTION
This PR implements the same code in JS for comparison.

This represents the "status quo" of MongoDB. The Node.JS driver is MongoDB's most popular driver and the official MongoDB driver is the most popular Node package for talking to MongoDB.

... not a high bar :)

I don't love it, but I think it would be totally fine to have something like `await prisma.$queryRawUnsafe(document)`, where document is one of the examples documents you provided.  This would: 

- give us and the Support team a way to provide a workaround for people wanting to do more advanced features
- allow people to migrate from Mongoose where you can do things like [Aggregation Pipelines](https://mongoosejs.com/docs/api/aggregate.html#aggregate_Aggregate)